### PR TITLE
Fix NameError in conversation.py

### DIFF
--- a/llava/conversation.py
+++ b/llava/conversation.py
@@ -4,6 +4,7 @@ import os
 import re
 from typing import List, Tuple
 import torchvision.transforms.functional as F
+from PIL import Image
 
 
 def parse_tool_output(text):


### PR DESCRIPTION
When I started up a gradio web server and sent an image and text, I encountered the following error.

```
2023-12-04 02:00:42 | ERROR | stderr |   File "/~~/LLaVA-Plus/llava/conversation.py", line 453, in remove_pil
2023-12-04 02:00:42 | ERROR | stderr |     if isinstance(x, Image.Image):
2023-12-04 02:00:42 | ERROR | stderr | NameError: name 'Image' is not defined
```

I added a line `from PIL import Image` in `llava/conversation.py` to resolve it.

This will probably also resolve issue #12.